### PR TITLE
Develop_23.08.07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "driver_matching_system_back",
       "version": "0.1.0",
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -20,6 +21,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -500,6 +502,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.13",
@@ -1375,6 +1386,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -5183,6 +5214,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
     },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/cors": {
       "version": "2.8.13",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
@@ -5841,6 +5881,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "author": "dongtimes2",
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -23,6 +24,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/morgan": "^1.9.4",

--- a/src/config/secretKey.ts
+++ b/src/config/secretKey.ts
@@ -5,3 +5,4 @@ export const SERVICE_SECRET_KEY = JSON.parse(
   process.env.SERVICE_SECRET_KEY as string
 );
 export const TOKEN_SECRET_KEY = process.env.TOKEN_SECRET_KEY as string;
+export const FRONT_URL = process.env.FRONT_URL;

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -2,13 +2,21 @@ import express, { Application } from "express";
 import cors from "cors";
 import morgan from "morgan";
 import { connectDB } from "./db.js";
+import cookieParser from "cookie-parser";
+import { FRONT_URL } from "../config/secretKey.js";
 
 const loaders = async (app: Application) => {
   await connectDB();
-  app.use(cors());
+  app.use(
+    cors({
+      origin: FRONT_URL,
+      credentials: true,
+    })
+  );
   app.use(morgan("dev"));
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
+  app.use(cookieParser());
 };
 
 export default loaders;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,12 +4,14 @@ interface IUser {
   _id: string;
   name: string;
   type: string;
+  refreshToken: string;
 }
 
 const UserSchema = new mongoose.Schema<IUser>({
-  _id: String,
-  name: { type: String, default: "", require: true },
-  type: { type: String, default: "", require: true },
+  _id: { type: String, default: "", required: true },
+  name: { type: String, default: "", required: true },
+  type: { type: String, default: "" },
+  refreshToken: { type: String, default: "" },
 });
 
 const User = mongoose.model<IUser>("User", UserSchema);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,10 +1,56 @@
 import { Router } from "express";
 import authentication from "../middlewares/authentication.js";
+import {
+  decodeAccessToken,
+  getAccessToken,
+  verifyRefreshToken,
+} from "../utils/token.js";
+import User from "../models/User.js";
 
 const router = Router();
 
 router.post("/signin", authentication, (req, res) => {
-  res.json({ accessToken: req.accessTokenData });
+  res.cookie("refreshToken", req.refreshTokenData, { httpOnly: true });
+  res.json({
+    accessToken: req.accessTokenData,
+  });
+});
+
+router.post("/refresh", async (req, res) => {
+  const { authorization } = req.headers;
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return res.status(401).json({
+      message: "access_token이 전달되지 않음",
+    });
+  }
+
+  const accessToken = authorization.split(" ")[1];
+  const { refreshToken } = req.cookies;
+  const uid = decodeAccessToken(accessToken);
+  const newAccessToken = getAccessToken(uid);
+
+  await verifyRefreshToken(uid, refreshToken);
+  res.json({
+    accessToken: newAccessToken,
+  });
+});
+
+router.post("/signout", async (req, res) => {
+  const { authorization } = req.headers;
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return res.status(401).json({
+      message: "access_token이 전달되지 않음",
+    });
+  }
+
+  const accessToken = authorization.split(" ")[1];
+  const uid = decodeAccessToken(accessToken);
+
+  await User.findByIdAndUpdate(uid, { refreshToken: "" });
+  res.clearCookie("refreshToken");
+  res.json({
+    message: "signout_OK",
+  });
 });
 
 export default router;

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,4 @@
+export interface IError {
+  name: string;
+  message: string;
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -4,6 +4,7 @@ declare global {
   namespace Express {
     interface Request {
       accessTokenData: string;
+      refreshTokenData: string;
       uidData: string;
     }
   }

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,0 +1,73 @@
+import jwt, { JwtPayload } from "jsonwebtoken";
+import { TOKEN_SECRET_KEY } from "../config/secretKey.js";
+import User from "../models/User.js";
+
+interface IDecodedToken extends JwtPayload {
+  uid: string;
+}
+
+export const getAccessToken = (uid: string) => {
+  const accessToken = jwt.sign({ uid }, TOKEN_SECRET_KEY, {
+    expiresIn: "3600s",
+  });
+
+  return accessToken;
+};
+
+export const getRefreshToken = async (uid: string) => {
+  const refreshTokenData = jwt.sign({}, TOKEN_SECRET_KEY, {
+    expiresIn: "14d",
+  });
+
+  await User.findByIdAndUpdate(uid, { refreshToken: refreshTokenData });
+
+  return refreshTokenData;
+};
+
+export const verifyAccessToken = (accessToken: string) => {
+  let result = "";
+
+  jwt.verify(accessToken, TOKEN_SECRET_KEY, (error, decoded) => {
+    if (error) {
+      if (error.name === "TokenExpiredError") {
+        throw Error("expired");
+      } else {
+        throw Error();
+      }
+    } else {
+      result = (decoded as IDecodedToken).uid;
+    }
+  });
+
+  return result;
+};
+
+// 토큰의 유효성은 검사하지 않고, 그저 decode만 수행한다.
+export const decodeAccessToken = (accessToken: string) => {
+  const { uid } = jwt.decode(accessToken) as IDecodedToken;
+
+  return uid;
+};
+
+export const verifyRefreshToken = async (uid: string, refreshToken: string) => {
+  jwt.verify(refreshToken, TOKEN_SECRET_KEY, (error) => {
+    if (error) {
+      if (error.name === "TokenExpiredError") {
+        throw Error("refresh_expired");
+      } else {
+        throw Error();
+      }
+    }
+  });
+
+  try {
+    const result = await User.findById(uid).lean();
+
+    if (result?.refreshToken === refreshToken) {
+      return;
+    }
+  } catch (error) {
+    console.error(error);
+    throw Error();
+  }
+};


### PR DESCRIPTION
# 변경점
- 기존에 구현된 access token이 만료되었을 때를 대비한 refresh token 로직 구현
원래는 refresh token을 response body에 json으로 보내게 구현하려하였으나, cookie에 담아서 보내는 것으로 변경하였음
- token에 관한 util 함수를 작성하였음. token을 이용하는 모든 함수에서, 명시적으로 token을 다루는 코드를 제거하였음.
- user schema에서 refresh token 값을 저장할 수 있도록 하여 token 검증에 활용할 수 있도록 하였음.